### PR TITLE
Fix copyright link

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -55,7 +55,7 @@
       {{config.footer}}
       {%- endif %}
       {%- if not config.hideNico %}
-      <p class="copyright">powered by <a href="{{system.url}}">{{system.name}}</a> {{system.version}}</p>
+      <p class="copyright">powered by <a href="{{system.homepage}}">{{system.name}}</a> {{system.version}}</p>
       {%- endif %}
     </div>
     {%- if config.github %}


### PR DESCRIPTION
The copyright link's `href` attribute was empty, add it again.