### PR TITLE
Using GitHub for comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This theme requires nico 0.4.6+ now.
 
 The basic configuration for a blog:
 
-```
+```json
 {
     "source": "content",
     "output": "_site",
@@ -40,7 +40,7 @@ Additional configuration this theme:
 
 Navigation example:
 
-```
+```json
 {
     "navigation": [
         {"title": "Life", "link": "/life/"},
@@ -55,7 +55,7 @@ Comment is available for posts. This theme support disqus and duoshuo.
 
 Configure a disqus short name:
 
-```
+```json
 {
     "disqus": "short name"
 }
@@ -63,8 +63,16 @@ Configure a disqus short name:
 
 If you prefer duoshuo:
 
-```
+```json
 {
     "duoshuo": "short name"
+}
+```
+
+Using Github for Comments:
+
+```json
+{
+    "githubIssues": "Your github issues url"
 }
 ```

--- a/static/one.css
+++ b/static/one.css
@@ -472,6 +472,16 @@ html, body {
   }
 }
 
+.github-comment {
+  border-top: 1px solid #eee;
+  padding-top: 10px;
+  color: #565655;
+  font-size: smaller;
+}
+.github-comment > img {
+  vertical-align: middle;
+}
+
 .document a.button {
   display: inline-block;
   padding: 1em;

--- a/static/site.css
+++ b/static/site.css
@@ -184,6 +184,16 @@ html, body {
   }
 }
 
+.github-comment {
+  border-top: 1px solid #eee;
+  padding-top: 10px;
+  color: #565655;
+  font-size: smaller;
+}
+.github-comment > img {
+  vertical-align: middle;
+}
+
 .document a.button {
   display: inline-block;
   padding: 1em;

--- a/templates/_comment.html
+++ b/templates/_comment.html
@@ -1,0 +1,66 @@
+<div class="github-comments"></div>
+<script type="text/javascript">
+  (function() {
+    var a = document.createElement('a'),
+      comments = document.getElementsByClassName('github-comments')[0],
+      api = 'https://api.github.com/repos',
+      issue = '{{ post.issue }}',
+      issueUrl;
+
+    a.href = '{{ config.githubIssues }}';
+
+    if (!issue) return false;
+    var matchs = issue.match(/(https?:\/\/github.com\/[^\s<>"]+)/);
+    if (matchs && matchs.length) {
+      // it may be a github issue url
+      api += matchs[0].replace(/^https?:\/\/github.com/, '') + '/comments';
+      issueUrl = matchs[0];
+    } else if (!isNaN(+ issue)) {
+      api += a.pathname + '/' + issue + '/comments';
+      issueUrl = a.href + '/' + issue;
+    } else {
+      throw Error('Invalid GitHub issue id or url');
+    }
+
+    if (window.fetch) {
+      // use fetch first
+      fetch(api, {
+        headers: new Headers({
+          'Accept': 'application/vnd.github.v3.html+json',
+          'Content-Type': 'application/json'
+        }),
+        method: 'GET'
+      }).then((res) => {
+        if (res.status == 200) return res.json();
+        var error = new Error('HTTP Exception[GET]');
+        error.status = res.status;
+        error.statusText = res.statusText;
+        error.url = res.url;
+        throw error;
+      }).then((json) => {
+          comments.insertAdjacentHTML('afterbegin',
+            '<h3>GitHub Comments</h3><p>Visit the <a href="' +
+            issueUrl +
+            '">GitHub Issue</a> to comment on this post.</p>'
+          );
+          json.forEach(function(comment){
+            var date = new Date(comment.created_at);
+            var c = '<div class="github-comment">' +
+                '<img src="' + comment.user.avatar_url + '" width="36"> ' +
+                '<a href="' + comment.user.html_url + '">' + comment.user.login + '</a>' +
+                ' posted at ' +
+                '<time>' + date.toUTCString() + '</time>' +
+                '<br>' +
+                comment.body_html +
+                '</div>';
+            comments.insertAdjacentHTML('beforeend', c);
+          });
+      }).catch((err) => {
+        comments.insertAdjacentHTML('afterbegin', '<h3>GitHub Comments</h3>' +
+          '<p>Comments are not open for this post yet.</p>');
+      });
+    } else {
+      // back down to XHR
+    }
+  })();
+</script>

--- a/templates/post.html
+++ b/templates/post.html
@@ -28,5 +28,8 @@
   {%- if config.duoshuo %}
   {%- include "_duoshuo.html" %}
   {%- endif %}
+  {%- if config.githubIssues %}
+  {%- include "_comment.html" %}
+  {%- endif %}
 </div>
 {% endblock -%}


### PR DESCRIPTION
Add a github comments prototype. It's need the nico add ability to [read github issue id or url from the meta of a post](https://github.com/lepture/nico/pull/75).

User can add a github issues url in `nico.json`, and specify a issue id in any post. If all is ok, will fetch comments from github and looks like this: 
 
<img width="706" alt="github-comments-in-nico-one-theme" src="https://cloud.githubusercontent.com/assets/9865150/25661752/6b62ca46-3044-11e7-9825-fecf2d144a0e.png">

